### PR TITLE
[Feat] Uses ROCK instead of upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ juju integrate sdcore-nrf sdcore-nssf
 
 ## Image
 
-- **nssf**: `omecproject/5gc-nssf:master-4e5aef3`
+- **nssf**: `ghcr.io/canonical/sdcore-nssf:1.3`

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   nssf-image:
     type: oci-image
     description: OCI image for 5G nssf
-    upstream-source: omecproject/5gc-nssf:master-4e5aef3
+    upstream-source: ghcr.io/canonical/sdcore-nssf:1.3
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -218,7 +218,7 @@ class NSSFOperatorCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": f"/free5gc/nssf/nssf --nssfcfg {CONFIG_DIR}/{CONFIG_FILE_NAME}",  # noqa: E501
+                        "command": f"/bin/nssf --nssfcfg {CONFIG_DIR}/{CONFIG_FILE_NAME}",  # noqa: E501
                         "environment": self._nssf_environment_variables,
                     },
                 },

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -152,7 +152,7 @@ class TestCharm(unittest.TestCase):
                 "nssf": {
                     "startup": "enabled",
                     "override": "replace",
-                    "command": "/free5gc/nssf/nssf --nssfcfg /free5gc/config/nssfcfg.conf",
+                    "command": "/bin/nssf --nssfcfg /free5gc/config/nssfcfg.conf",
                     "environment": {
                         "GOTRACEBACK": "crash",
                         "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
@@ -246,7 +246,7 @@ class TestCharm(unittest.TestCase):
                     "nssf": {
                         "startup": "enabled",
                         "override": "replace",
-                        "command": "/free5gc/nssf/nssf --nssfcfg /free5gc/config/nssfcfg.conf",
+                        "command": "/bin/nssf --nssfcfg /free5gc/config/nssfcfg.conf",
                         "environment": {
                             "GOTRACEBACK": "crash",
                             "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
@@ -293,7 +293,7 @@ class TestCharm(unittest.TestCase):
                     "nssf": {
                         "startup": "enabled",
                         "override": "replace",
-                        "command": "/free5gc/nssf/nssf --nssfcfg /free5gc/config/nssfcfg.conf",
+                        "command": "/bin/nssf --nssfcfg /free5gc/config/nssfcfg.conf",
                         "environment": {
                             "GOTRACEBACK": "crash",
                             "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",


### PR DESCRIPTION
# Description

Uses nssf ROCK instead of the upstream image.

Don't merge until the [ROCK](https://github.com/canonical/sdcore-nssf-rock/pull/1) is merged.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library