### PR TITLE
Enforce TLS Integration

### DIFF
--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -12,7 +12,7 @@ configuration:
     bindingIPv4: 0.0.0.0
     port: 29531
     registerIPv4: 1.1.1.1
-    scheme: http
+    scheme: https
   serviceNameList:
   - nnssf-nsselection
   - nnssf-nssaiavailability

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -43,8 +43,24 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
+    def test_given_certificates_relation_not_created_when_pebble_ready_then_status_is_blocked(
+        self,
+    ):
+        state_in = State(
+            leader=True,
+            containers=[self.container],
+            relations=[self.nrf_relation],
+        )
+
+        state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
+
+        self.assertEqual(
+            state_out.unit_status,
+            BlockedStatus("Waiting for certificates relation"),
+        )
+
     @patch("charm.check_output")
-    def test_given_ausf_charm_in_active_status_when_nrf_relation_breaks_then_status_is_blocked(
+    def test_given_nssf_charm_in_active_status_when_nrf_relation_breaks_then_status_is_blocked(
         self, patch_check_output
     ):
         config_dir = tempfile.TemporaryDirectory()
@@ -66,6 +82,29 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
+    @patch("charm.check_output")
+    def test_given_nssf_charm_in_active_status_when_certificates_relation_breaks_then_status_is_blocked(  # noqa: E501
+        self, patch_check_output
+    ):
+        config_dir = tempfile.TemporaryDirectory()
+        container = self.container.replace(
+            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+        )
+        state_in = State(
+            leader=True,
+            containers=[container],
+            relations=[self.nrf_relation, self.tls_relation],
+            unit_status=ActiveStatus(),
+        )
+        patch_check_output.return_value = "1.1.1.1".encode()
+
+        state_out = self.ctx.run(self.tls_relation.broken_event, state_in)
+
+        self.assertEqual(
+            state_out.unit_status,
+            BlockedStatus("Waiting for certificates relation"),
+        )
+
     def test_given_nrf_data_not_available_when_pebble_ready_then_status_is_waiting(
         self,
     ):
@@ -73,7 +112,7 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[self.container],
-            relations=[nrf_relation],
+            relations=[nrf_relation, self.tls_relation],
         )
 
         state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
@@ -93,7 +132,7 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[self.container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
 
         state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
@@ -108,7 +147,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    def test_given_relations_created_and_nrf_data_available_when_pebble_ready_then_config_file_rendered_and_pushed(  # noqa: E501
+    def test_given_relation_created_and_nrf_data_available_and_certificates_not_stored_when_pebble_ready_then_status_is_waiting(  # noqa: E501
         self,
         patch_check_output,
     ):
@@ -119,10 +158,40 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
+        )
+
+        patch_check_output.return_value = b"1.1.1.1"
+        state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
+
+        self.assertEqual(
+            state_out.unit_status,
+            WaitingStatus("Waiting for certificates to be stored"),
+        )
+        self.assertEqual(
+            state_out.deferred[0].name,
+            "nssf_pebble_ready",
+        )
+
+    @patch("ops.model.Container.exists")
+    @patch("charm.check_output")
+    def test_given_relations_created_and_nrf_data_available_and_certificates_stored_when_pebble_ready_then_config_file_rendered_and_pushed(  # noqa: E501
+        self,
+        patch_check_output,
+        patch_exists,
+    ):
+        config_dir = tempfile.TemporaryDirectory()
+        container = self.container.replace(
+            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+        )
+        state_in = State(
+            leader=True,
+            containers=[container],
+            relations=[self.nrf_relation, self.tls_relation],
             model=Model(name="whatever"),
         )
         patch_check_output.return_value = b"1.1.1.1"
+        patch_exists.return_value = True
 
         self.ctx.run(container.pebble_ready_event, state_in)
 
@@ -134,10 +203,12 @@ class TestCharm(unittest.TestCase):
             expected_content = expected.read().strip()
             self.assertEqual(actual_content, expected_content)
 
+    @patch("ops.model.Container.exists")
     @patch("charm.check_output")
     def test_config_pushed_but_content_changed_when_pebble_ready_then_new_config_content_is_pushed(  # noqa: E501
         self,
         patch_check_output,
+        patch_exists,
     ):
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
@@ -146,10 +217,11 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
             model=Model(name="whatever"),
         )
         patch_check_output.return_value = "1.1.1.1".encode()
+        patch_exists.return_value = True
         with open(Path(config_dir.name) / "nssfcfg.conf", "w") as existing_config:
             existing_config.write("never gonna give you up")
 
@@ -163,10 +235,12 @@ class TestCharm(unittest.TestCase):
             expected_content = expected.read().strip()
             self.assertEqual(actual_content, expected_content)
 
+    @patch("ops.model.Container.exists")
     @patch("charm.check_output")
     def test_given_relation_available_and_config_pushed_when_pebble_ready_then_pebble_layer_is_added_correctly(  # noqa: E501
         self,
         patch_check_output,
+        patch_exists,
     ):
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
@@ -175,9 +249,10 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
+        patch_exists.return_value = True
 
         state_out = self.ctx.run(container.pebble_ready_event, state_in)
 
@@ -202,10 +277,12 @@ class TestCharm(unittest.TestCase):
         updated_plan = state_out.containers[0].layers["nssf"]
         self.assertEqual(expected_plan, updated_plan)
 
+    @patch("ops.model.Container.exists")
     @patch("charm.check_output")
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_status_is_active(  # noqa: E501
         self,
         patch_check_output,
+        patch_exists,
     ):
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
@@ -214,9 +291,10 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
+        patch_exists.return_value = True
 
         state_out = self.ctx.run(container.pebble_ready_event, state_in)
 
@@ -237,7 +315,7 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = "".encode()
 
@@ -248,12 +326,14 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for pod IP address to be available"),
         )
 
+    @patch("ops.model.Container.exists")
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_service_is_restarted(  # noqa: E501
         self,
         patch_check_output,
         patch_restart,
+        patch_exists,
     ):
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
@@ -262,9 +342,10 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
+        patch_exists.return_value = True
 
         self.ctx.run(container.pebble_ready_event, state_in)
 
@@ -317,12 +398,14 @@ class TestCharm(unittest.TestCase):
 
         patch_restart.assert_not_called()
 
+    @patch("ops.model.Container.exists")
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
     def test_config_pushed_but_content_changed_and_layer_already_applied_when_pebble_ready_then_nssf_service_is_restarted(  # noqa: E501
         self,
         patch_check_output,
         patch_restart,
+        patch_exists,
     ):
         config_dir = tempfile.TemporaryDirectory()
         applied_plan = Layer(
@@ -352,10 +435,11 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
             model=Model(name="whatever"),
         )
         patch_check_output.return_value = "1.1.1.1".encode()
+        patch_exists.return_value = True
 
         self.ctx.run(container.pebble_ready_event, state_in)
 


### PR DESCRIPTION
# Description

Enforces TLS integration in the charm. Charm remains in blocked state until the `certificates` relation is created, and in waiting status until a certificate is stored.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library