### PR TITLE
Set units to blocked status when scaling beyond 1

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -47,7 +47,13 @@ class NSSFOperatorCharm(CharmBase):
     def __init__(self, *args) -> None:
         super().__init__(*args)
         if not self.unit.is_leader():
-            raise NotImplementedError("Scaling is not implemented for this charm")
+            # NOTE: In cases where leader status is lost before the charm is
+            # finished processing all teardown events, this prevents teardown
+            # event code from running. Luckily, for this charm, none of the
+            # teardown code is necessary to preform if we're removing the
+            # charm.
+            self.unit.status = BlockedStatus("Scaling is not implemented for this charm")
+            return
         self._container_name = self._service_name = "nssf"
         self._container = self.unit.get_container(self._container_name)
         self._nrf_requires = NRFRequires(charm=self, relation_name="fiveg_nrf")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,8 +4,10 @@
 
 
 import asyncio
+from collections import Counter
 import logging
 from pathlib import Path
+from juju.application import Application
 
 import pytest
 import yaml
@@ -125,3 +127,21 @@ async def test_restore_tls_and_wait_for_active_status(ops_test, build_and_deploy
         relation1=APP_NAME, relation2=TLS_PROVIDER_NAME
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_when_scale_app_beyond_1_then_only_one_unit_is_active(
+    ops_test: OpsTest, build_and_deploy
+):
+    assert ops_test.model
+    assert isinstance(app := ops_test.model.applications[APP_NAME], Application)
+    await app.scale(3)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000, wait_for_at_least_units=3)
+    unit_statuses = Counter(unit.workload_status for unit in app.units)
+    assert unit_statuses.get("active") == 1
+    assert unit_statuses.get("blocked") == 2
+
+
+async def test_remove_app(ops_test: OpsTest, build_and_deploy):
+    assert ops_test.model
+    await ops_test.model.remove_application(APP_NAME, block_until_done=True)


### PR DESCRIPTION
Instead of throwing an error, block the units when scaled beyond 1.

Throwing an error causes the charm to go into a bad state, where it can't even be removed without manual intervention. This even causes an issue with a single unit, as sometimes leader status is removed before the charm has finished processing all events.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library