### PR TITLE
fix: Checks if certificate is already requested

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -161,7 +161,9 @@ class NSSFOperatorCharm(CharmBase):
         if not self._private_key_is_stored():
             event.defer()
             return
-        self._request_new_certificate()
+        if not self._certificate_is_stored():
+            self._request_new_certificate()
+            return
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Pushes certificate to workload and configures workload."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -161,9 +161,10 @@ class NSSFOperatorCharm(CharmBase):
         if not self._private_key_is_stored():
             event.defer()
             return
-        if not self._certificate_is_stored():
-            self._request_new_certificate()
+        if self._certificate_is_stored():
             return
+
+        self._request_new_certificate()
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Pushes certificate to workload and configures workload."""


### PR DESCRIPTION
# Description

Adds a guard in the certificates relation joined handler to check if the cert was already stored before requesting a new one.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library