### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@main
     with:
-      charm-file-name: "sdcore-nssf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-nssf-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,5 +39,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-nssf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-nssf-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# SD-Core NSSF Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-nssf/badge.svg)](https://charmhub.io/sdcore-nssf)
+# SD-Core NSSF K8s Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-nssf-k8s/badge.svg)](https://charmhub.io/sdcore-nssf-k8s)
 
-Charmed Operator for the SD-Core Network Slice Selection Function (NSSF).
+Charmed K8s Operator for the SD-Core Network Slice Selection Function (NSSF).
 
 ## Usage
 ```bash
 juju deploy mongodb-k8s --trust --channel=5/edge
-juju deploy sdcore-nrf --channel=edge
-juju deploy sdcore-nssf --channel=edge
+juju deploy sdcore-nrf-k8s --channel=edge
+juju deploy sdcore-nssf-k8s --channel=edge
 juju deploy self-signed-certificates --channel=beta
 juju integrate mongodb-k8s sdcore-nrf
-juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
-juju integrate sdcore-nrf sdcore-nssf
-juju integrate sdcore-nssf:certificates self-signed-certificates:certificates
+juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
+juju integrate sdcore-nrf-k8s sdcore-nssf-k8s
+juju integrate sdcore-nssf-k8s:certificates self-signed-certificates:certificates
 ```
 
 ## Image

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core NSSF Operator  for K8s
+# SD-Core NSSF Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-nssf-k8s/badge.svg)](https://charmhub.io/sdcore-nssf-k8s)
 
 Charmed Operator for the SD-Core Network Slice Selection Function (NSSF) for K8s.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core NSSF K8s Operator
+# SD-Core NSSF Operator  for K8s
 [![CharmHub Badge](https://charmhub.io/sdcore-nssf-k8s/badge.svg)](https://charmhub.io/sdcore-nssf-k8s)
 
-Charmed K8s Operator for the SD-Core Network Slice Selection Function (NSSF).
+Charmed Operator for the SD-Core Network Slice Selection Function (NSSF) for K8s.
 
 ## Usage
 ```bash

--- a/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
@@ -13,7 +13,7 @@ NRF information and another charm requiring this information.
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_nrf.v0.fiveg_nrf
+charmcraft fetch-lib charms.sdcore_nrf_k8s.v0.fiveg_nrf
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -28,7 +28,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFProvides
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFProvides
 
 
 class DummyFiveGNRFProviderCharm(CharmBase):
@@ -103,14 +103,14 @@ from ops.model import Relation
 from pydantic import AnyHttpUrl, BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "cd132a12c2b34243bfd2bae8d08c32d6"
+LIBID = "14746bb6f8d34accbeac27ea50ff4715"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,12 +1,12 @@
-name: sdcore-nssf
+name: sdcore-nssf-k8s
 
-display-name: SD-Core 5G NSSF
+display-name: SD-Core 5G NSSF K8s
 summary: A Charmed Operator for SD-Core's Network Slice Selection Function (NSSF).
 description: |
   A Charmed Operator for SD-Core's Network Slice Selection Function (NSSF).
-website: https://charmhub.io/sdcore-nssf
-source: https://github.com/canonical/sdcore-nssf-operator
-issues: https://github.com/canonical/sdcore-nssf-operator/issues
+website: https://charmhub.io/sdcore-nssf-k8s
+source: https://github.com/canonical/sdcore-nssf-k8s-operator
+issues: https://github.com/canonical/sdcore-nssf-k8s-operator/issues
 
 containers:
   nssf:

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,7 @@ from ipaddress import IPv4Address
 from subprocess import check_output
 from typing import Optional
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateAvailableEvent,
     CertificateExpiringEvent,

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the SD-Core NSSF K8s service."""
+"""Charmed operator for the SD-Core NSSF service for K8s."""
 
 import logging
 from ipaddress import IPv4Address
@@ -37,8 +37,8 @@ CERTIFICATE_NAME = "nssf.pem"
 CERTIFICATE_COMMON_NAME = "nssf.sdcore"
 
 
-class NSSFK8sOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the SD-Core NSSF K8s operator."""
+class NSSFOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the SD-Core NSSF operator for K8s."""
 
     def __init__(self, *args) -> None:
         super().__init__(*args)
@@ -448,4 +448,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(NSSFK8sOperatorCharm)
+    main(NSSFOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the SD-Core NSSF service."""
+"""Charmed operator for the SD-Core NSSF K8s service."""
 
 import logging
 from ipaddress import IPv4Address
@@ -37,8 +37,8 @@ CERTIFICATE_NAME = "nssf.pem"
 CERTIFICATE_COMMON_NAME = "nssf.sdcore"
 
 
-class NSSFOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the SD-Core NSSF operator."""
+class NSSFK8sOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the SD-Core NSSF K8s operator."""
 
     def __init__(self, *args) -> None:
         super().__init__(*args)
@@ -448,4 +448,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(NSSFOperatorCharm)
+    main(NSSFK8sOperatorCharm)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -19,7 +19,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 DB_APPLICATION_NAME = "mongodb-k8s"
-NRF_APPLICATION_NAME = "sdcore-nrf"
+NRF_APPLICATION_NAME = "sdcore-nrf-k8s"
 TLS_PROVIDER_NAME = "self-signed-certificates"
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,12 +13,12 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer
 from scenario import Container, Context, Model, Mount, Relation, State  # type: ignore[import]
 
-from charm import NSSFOperatorCharm
+from charm import NSSFK8sOperatorCharm
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.ctx = Context(NSSFOperatorCharm)
+        self.ctx = Context(NSSFK8sOperatorCharm)
         self.container = Container(name="nssf", can_connect=True)
         self.nrf_relation = Relation(
             endpoint="fiveg_nrf",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,12 +13,12 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer
 from scenario import Container, Context, Model, Mount, Relation, State  # type: ignore[import]
 
-from charm import NSSFK8sOperatorCharm
+from charm import NSSFOperatorCharm
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.ctx = Context(NSSFK8sOperatorCharm)
+        self.ctx = Context(NSSFOperatorCharm)
         self.container = Container(name="nssf", can_connect=True)
         self.nrf_relation = Relation(
             endpoint="fiveg_nrf",


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit) . 

- Fetch new fiveg_nrf library
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library